### PR TITLE
add support for osx

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -34,6 +34,18 @@
         <source-file src="src/ios/CDVClipboard.m" />
     </platform>
 
+    <!-- OS X -->
+    <platform name="osx">
+        <config-file target="config.xml" parent="/*">
+            <feature name="Clipboard">
+                <param name="ios-package" value="CDVClipboard" />
+            </feature>
+        </config-file>
+
+        <header-file src="src/osx/CDVClipboard.h" />
+        <source-file src="src/osx/CDVClipboard.m" />
+    </platform>
+
     <!-- Android -->
     <platform name="android">
         <source-file src="src/android/Clipboard.java" target-dir="src/com/verso/cordova/clipboard" />

--- a/src/android/Clipboard.java
+++ b/src/android/Clipboard.java
@@ -23,13 +23,11 @@ public class Clipboard extends CordovaPlugin {
 
         if (ACTION_COPY.equals(action)) {
             try {
-                String text = args.getString(0);
+                final String text = args.getString(0);
                 ClipData clip = ClipData.newPlainText("Text", text);
-
                 clipboard.setPrimaryClip(clip);
 
                 callbackContext.success(text);
-
                 return true;
             } catch (JSONException e) {
                 callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.JSON_EXCEPTION));
@@ -38,13 +36,13 @@ public class Clipboard extends CordovaPlugin {
             }
         } else if (ACTION_PASTE.equals(action)) {
             try {
-                ClipData.Item item = clipboard.getPrimaryClip().getItemAt(0);
-                String text = item.getText().toString();
-
-                if (text == null) text = "";
-
+                String text = "";
+                ClipData clip = clipboard.getPrimaryClip();
+                if (clip != null) {
+                    ClipData.Item item = clip.getItemAt(0);
+                    text = item.getText().toString();
+                }
                 callbackContext.success(text);
-
                 return true;
             } catch (Exception e) {
                 callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.ERROR, e.toString()));

--- a/src/android/Clipboard.java
+++ b/src/android/Clipboard.java
@@ -14,14 +14,14 @@ import android.content.ClipDescription;
 
 public class Clipboard extends CordovaPlugin {
 
-    private static final String actionCopy = "copy";
-    private static final String actionPaste = "paste";
+    private static final String ACTION_COPY = "copy";
+    private static final String ACTION_PASTE = "paste";
 
     @Override
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
         ClipboardManager clipboard = (ClipboardManager) cordova.getActivity().getSystemService(Context.CLIPBOARD_SERVICE);
 
-        if (action.equals(actionCopy)) {
+        if (ACTION_COPY.equals(action)) {
             try {
                 String text = args.getString(0);
                 ClipData clip = ClipData.newPlainText("Text", text);
@@ -36,11 +36,7 @@ public class Clipboard extends CordovaPlugin {
             } catch (Exception e) {
                 callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.ERROR, e.toString()));
             }
-        } else if (action.equals(actionPaste)) {
-            if (!clipboard.getPrimaryClipDescription().hasMimeType(ClipDescription.MIMETYPE_TEXT_PLAIN)) {
-                callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.NO_RESULT));
-            }
-
+        } else if (ACTION_PASTE.equals(action)) {
             try {
                 ClipData.Item item = clipboard.getPrimaryClip().getItemAt(0);
                 String text = item.getText().toString();
@@ -54,9 +50,6 @@ public class Clipboard extends CordovaPlugin {
                 callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.ERROR, e.toString()));
             }
         }
-
         return false;
     }
 }
-
-

--- a/src/ios/CDVClipboard.m
+++ b/src/ios/CDVClipboard.m
@@ -21,6 +21,9 @@
 	[self.commandDelegate runInBackground:^{
 		UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
 		NSString *text = [pasteboard valueForPasteboardType:@"public.text"];
+		if (text == nil) {
+			text = @"";
+		}
 
 		CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:text];
 		[self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];

--- a/src/osx/CDVClipboard.h
+++ b/src/osx/CDVClipboard.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+#import <Cordova/CDVPlugin.h>
+
+@interface CDVClipboard : CDVPlugin {}
+
+- (void)copy:(CDVInvokedUrlCommand*)command;
+- (void)paste:(CDVInvokedUrlCommand*)command;
+
+@end

--- a/src/osx/CDVClipboard.m
+++ b/src/osx/CDVClipboard.m
@@ -7,10 +7,11 @@
 
 - (void)copy:(CDVInvokedUrlCommand*)command {
 	[self.commandDelegate runInBackground:^{
-		UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
+		NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
 		NSString *text = [command.arguments objectAtIndex:0];
 
-		[pasteboard setValue:text forPasteboardType:@"public.text"];
+		[pasteboard clearContents];
+		[pasteboard setString:text forType:NSStringPboardType];
 
 		CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:text];
 		[self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -19,8 +20,11 @@
 
 - (void)paste:(CDVInvokedUrlCommand*)command {
 	[self.commandDelegate runInBackground:^{
-		UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
-		NSString *text = [pasteboard valueForPasteboardType:@"public.text"];
+		NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
+		NSString *text = [pasteboard stringForType:NSPasteboardTypeString];
+		if (text == nil) {
+			text = @"";
+		}
 
 		CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:text];
 		[self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];


### PR DESCRIPTION
Hi HootsuiteLabs,

I forked your fork of CordovaClipboard (since of [the many forks of the original](https://github.com/VersoSolutions/CordovaClipboard/network), yours looks like the most maintained?) to add support for OS X.

Please feel free to pull the changes if you and/or others who depend on your fork might find them useful too.

If there is some other fork you recommend submitting these to, please let me know.

Thanks!